### PR TITLE
ci(dependabot): group npm and github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,15 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    groups:
+      npm-dependencies:
+        patterns:
+          - '*'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'daily'
+    groups:
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
## What

Group Dependabot updates so daily bumps arrive as a single PR per ecosystem instead of one PR per dependency.

- **npm** → group `npm-dependencies` (`patterns: ['*']`)
- **github-actions** → group `github-actions` (`patterns: ['*']`)

The `daily` schedule is unchanged — grouping only affects how updates are batched into PRs.

## Diff

```yaml
  - package-ecosystem: 'npm'
    directory: '/'
    schedule:
      interval: 'daily'
+   groups:
+     npm-dependencies:
+       patterns:
+         - '*'
  - package-ecosystem: 'github-actions'
    directory: '/'
    schedule:
      interval: 'daily'
+   groups:
+     github-actions:
+       patterns:
+         - '*'
```

## Notes

- The existing `dependabot_auto_merge` job is unaffected: `dependabot/fetch-metadata` reports the aggregated `update-type` for grouped PRs, so patch/minor groups still auto-merge and any group containing a major bump is held for review.
- Validated as well-formed YAML locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
